### PR TITLE
インクルードのマクロを修正

### DIFF
--- a/ICM42688P_HAL_I2C.cpp
+++ b/ICM42688P_HAL_I2C.cpp
@@ -7,9 +7,9 @@
 
 #ifdef USE_HAL_DRIVER
 
-#ifdef HAL_I2C_MODULE_ENABLED
-
 #include "ICM42688P_HAL_I2C.h"
+
+#ifdef HAL_I2C_MODULE_ENABLED
 
 ICM42688P_HAL_I2C::ICM42688P_HAL_I2C(I2C_HandleTypeDef* i2c_pin){
 
@@ -27,5 +27,4 @@ void ICM42688P_HAL_I2C::Read(ICM42688P::BANK0 reg_addr, uint8_t* rx_buffer, uint
 }
 
 #endif /* HAL_I2C_MODULE_ENABLED */
-
 #endif /* USE_HAL_DRIVER */

--- a/ICM42688P_HAL_I2C.h
+++ b/ICM42688P_HAL_I2C.h
@@ -8,6 +8,10 @@
 #ifndef SRC_ICM42688P_HAL_I2C_H_
 #define SRC_ICM42688P_HAL_I2C_H_
 
+#ifdef USE_HAL_DRIVER
+
+#include "main.h"
+
 #ifdef HAL_I2C_MODULE_ENABLED
 
 #include "ICM42688P.h"
@@ -28,5 +32,6 @@ class ICM42688P_HAL_I2C: public ICM42688P {
         const uint8_t i2c_addr = 0b1101000 << 1;
 };
 
-#endif /* SRC_ICM42688P_HAL_I2C_H_ */
 #endif /* HAL_I2C_MODULE_ENABLED */
+#endif /* USE_HAL_DRIVER */
+#endif /* SRC_ICM42688P_HAL_I2C_H_ */

--- a/ICM42688P_HAL_SPI.cpp
+++ b/ICM42688P_HAL_SPI.cpp
@@ -5,8 +5,6 @@
  *      Author: Sezakiaoi
  */
 
-#ifdef USE_HAL_DRIVER
-
 #ifdef HAL_SPI_MODULE_ENABLED
 
 #include "ICM42688P_HAL_SPI.h"
@@ -59,5 +57,5 @@ void ICM42688P_HAL_SPI::Read(ICM42688P::BANK0 reg_addr, uint8_t* rx_buffer, uint
 }
 
 #endif /* HAL_SPI_MODULE_ENABLED */
-#endif /* USE_HAL_DRIVER */
+
 

--- a/ICM42688P_HAL_SPI.h
+++ b/ICM42688P_HAL_SPI.h
@@ -31,5 +31,5 @@
 		 uint16_t cs_pin_num = 0x00;
  };
  
+ #endif /* HAL_SPI_MODULE_ENABLED */
  #endif /* INC_ICM42688P_HAL_SPI_H_ */
-#endif /* HAL_SPI_MODULE_ENABLED */


### PR DESCRIPTION
stm32側のマクロでmain.hをインクルードしていなかったことで、モジュール周りのマクロが動作していなかった不具合を修正。STM32_HAL、Arudino以外で使用する場合はさらなる変更が必要なので注意